### PR TITLE
Remove references to deleted SVG files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+// Removed imports and references to deleted SVG files
 import './App.css'
 
 function App() {
@@ -9,12 +8,7 @@ function App() {
   return (
     <>
       <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+        {/* Links and images removed */}
       </div>
       <h1>Vite + React</h1>
       <div className="card">


### PR DESCRIPTION
Updated `src/App.tsx` to remove references to `src/assets/react.svg` and `public/vite.svg`, following their deletion in the 'Cleanup Unnecessary Files' pull request. This change ensures the application's functionality remains intact without relying on these deleted assets.